### PR TITLE
Parallel file read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,54 @@
+# Temporary and binary files
+*~
+*.py[cod]
+*.so
+*.cfg
+!.isort.cfg
+!setup.cfg
+*.orig
+*.log
+*.pot
+__pycache__/*
+.cache/*
+.*.swp
+*/.ipynb_checkpoints/*
+.DS_Store
+
+# Project files
+.ropeproject
+.project
+.pydevproject
+.settings
+.idea
+.vscode
+tags
+
+# Package files
+*.egg
+*.eggs/
+.installed.cfg
+*.egg-info
+
+# Unittest and coverage
+htmlcov/*
+.coverage
+.coverage.*
+.tox
+junit*.xml
+coverage.xml
+.pytest_cache/
+
+# Build and docs folder/files
+build/*
+dist/*
+sdist/*
+docs/api/*
+docs/_rst/*
+docs/_build/*
+cover/*
+MANIFEST
+
+# Per-project virtualenvs
+.venv*/
+.conda*/
+.python-version

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ reconstruct_data(filename_template='../frames/PdCPTN01002_%05i.cbf',
         scale=None) #Here you can provide a list of coefficients to scale each frame during reconstruction, for instance in a crystal which was unevenly illuminated during experiment, or the primary beam intensity was varying.
 ```
 
+### Parallel usage
+
+In order to speed up the reconstruction, Meerkat can be run in parallel as a command line script. This can be achieved by running the following command:
+
+``` bash
+python -m meerkat.meerkat filename_template first_image last_image maxind number_of_pixels 
+```
+
+A number of other options can be supplied to the script, see `python -m meerkat.meerkat --help` for more details.
+
+
 ## Output
 The result is saved as an [hdf5](“http://www.hdfgroup.org/HDF5/”) file. The reconstruction is held in two datasets: `rebinned_data` and `number_of_pixels_rebinned`, the former is a corrected sum of intensities of reconstructed pixels, while the latter counts how many pixels were reconstructed. The scattering intensity can be obtained by dividing the two: `rebinned_data[i,j,k]/number_of_pixels_rebinned[i,j,k]`.
 

--- a/meerkat/__init__.py
+++ b/meerkat/__init__.py
@@ -2,4 +2,4 @@
 A python library for performing reciprocal space reconstruction from single crystal x-ray measurements.
 """
 
-from .meerkat import *
+#from .meerkat import *


### PR DESCRIPTION
# Problem

When reading highly compressed image files a fairly large amount of time is spent decompressing the images, rather than performing the reconstruction. 

# Potential solution

Using multiprocessing, it's possible to split the work of reading files and reconstructing asynchronously across processors. Ideally this would parallelise both the reading and reconstruction steps, but given that h5py cannot perform parallel writes I opted to just parallelise the read operation.

This fork uses a Pool of workers (default 4) to read image files and yield the results as needed to a single worker which does the reconstruction. To avoid i/o out-running the reconstruction (and filling memory) the Pool is restricted to storing a maximum of 8 images. On the few test-cases I've run, it seems to give a fairly good speedup.

To use the parallel processing, meerkat must be called as an importable script - I've used argparse to collect (some of) the parameters for `reconstruct_data` from the command line, and the whole lot can be called with `python -m meerkat.meerkat --help`

# Possible Downsides

- In order to implement parallel reading, I've had to modify `reconstuct_data` to take an iterable of (image_number, data) pairs instead of the previous `filename_template`, and also a `semaphore` object (default None) to work with multiprocessing. This change would change the API, but could also allow the use of `fabio.frame_series` which has some (potential) speed advantages.
- Parallel processing can only be performed as a script. This is a limitation of multiprocessing, and difficult to overcome...